### PR TITLE
Add workflow template

### DIFF
--- a/.github/workflows/always_fail_workflow.yaml
+++ b/.github/workflows/always_fail_workflow.yaml
@@ -1,0 +1,27 @@
+name: Always Fail Status Check
+
+on: [push, pull_request]
+
+env:
+  NODE_VERSION: 16.15.0
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [16]
+
+    name: Always Fail until proper checks are in place
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Informational Message
+        run: echo You need to setup proper branch protection rules and status checks
+
+      - name: Force Fail
+        run: exit 99


### PR DESCRIPTION
We are implementing ISO27001 standards. One of those standards is enforcing CI status checks in branch protection rules for a repositories default branch. This repository was found to not have a CI status check in place. As a result we are automatically creating a check that will fail, preventing any merge from happening into the default branch until such a check is put in place properly.